### PR TITLE
Remove non-blocking option.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,2 +1,5 @@
+0.9.1 (2013-09-27)
+* Remove 'blocking' parameter
+
 0.9 (2013-08-23)
 * Initial public release.

--- a/lib/vchan.mli
+++ b/lib/vchan.mli
@@ -34,32 +34,29 @@ module Make (Xs: Xs_client_lwt.S) : sig
       currently connected to an endpoint. *)
 
   val server :
-    blocking:bool ->
     evtchn_h:Eventchn.handle ->
     domid:int ->
     xs_path:string ->
     read_size:int ->
     write_size:int ->
     persist:bool -> t Lwt.t
-  (** [server ~blocking ~evtchn_h ~domid ~xs_path ~read_size
+  (** [server ~evtchn_h ~domid ~xs_path ~read_size
       ~write_size ~persist] initializes a vchan server listening to
       connections from domain [~domid], using connection information
       from [~xs_path], with left ring of size [~read_size] and right
       ring of size [~write_size], which accepts reconnections
-      depending on the value of [~persist]. If [~blocking] is [true],
-      the reading and writing functions will poll rather than block on
-      a notification. The [~eventchn] argument is necessary because
-      under Unix, handles do not see events from other handles. *)
+      depending on the value of [~persist].  The [~eventchn] argument 
+      is necessary because under Unix, handles do not see events from
+      other handles. *)
 
   val client :
-    blocking:bool ->
     evtchn_h:Eventchn.handle ->
     domid:int ->
     xs_path:string -> t Lwt.t
-  (** [client ~blocking ~evtchn_h ~domid ~xs_path] initializes a vchan
+  (** [client ~evtchn_h ~domid ~xs_path] initializes a vchan
       client to communicate with domain [~domid] using connection
       information from [~xs_path]. See the above function for the
-      definition of fields [~blocking] and [~evtchn_h]. *)
+      definition of field [~evtchn_h]. *)
 
   val close : t -> unit
   (** Close a vchan. This deallocates the vchan and attempts to free

--- a/test/node.ml
+++ b/test/node.ml
@@ -6,14 +6,14 @@ let (>>=) = Lwt.bind
 
 module V = Vchan.Make(Xs)
 
-let with_vchan blocking clisrv evtchn_h domid nodepath f =
+let with_vchan clisrv evtchn_h domid nodepath f =
   (match clisrv with
    | Client ->
      Printf.printf "I'm a client, connecting to domid %d using xs_path %s.\n%!" domid nodepath;
-     V.client ~blocking ~evtchn_h ~domid ~xs_path:nodepath
+     V.client ~evtchn_h ~domid ~xs_path:nodepath
    | Server ->
      Printf.printf "Initializing Server domid=%d xs_path=%s\n%!" domid nodepath;
-     V.server ~blocking ~evtchn_h ~domid ~xs_path:nodepath
+     V.server ~evtchn_h ~domid ~xs_path:nodepath
        ~read_size:5000 ~write_size:5000 ~persist:true)
   >>= fun vch ->
   Printf.printf "Initialization done!\n%!";

--- a/test/node_cli.ml
+++ b/test/node_cli.ml
@@ -1,5 +1,6 @@
 open Cmdliner
 open Node
+open OS
 
 type op = Read | Write
 
@@ -61,8 +62,7 @@ let with_vchan_f op vch = match op with
 let node clisrv rw domid nodepath : unit Lwt.t = Lwt_main.run (
     (* Listen to incoming events. *)
     let evtchn_h = Eventchn.init () in
-    Lwt.async (fun () -> Activations.run evtchn_h);
-    Node.with_vchan false clisrv evtchn_h domid nodepath (with_vchan_f rw))
+    Node.with_vchan clisrv evtchn_h domid nodepath (with_vchan_f rw))
 
 let cmd =
   let doc = "Vchan testing" in

--- a/test/node_mirage.ml
+++ b/test/node_mirage.ml
@@ -4,7 +4,6 @@ open Node
 (* Config **********************************************************)
 let clisrv = Server
 let remote_domid = 0 (* Serve dom0 *)
-let blocking = true
 (*******************************************************************)
 
 let buf = String.create 5000
@@ -15,4 +14,4 @@ let rec echo vch =
   echo vch
 
 let main () =
-  Node.with_vchan blocking clisrv (Eventchn.init ()) remote_domid "data/vchan" echo
+  Node.with_vchan clisrv (Eventchn.init ()) remote_domid "data/vchan" echo

--- a/test/xs.ml
+++ b/test/xs.ml
@@ -1,2 +1,0 @@
-include Xs_client_lwt.Client(Xs_transport_lwt_unix_client)
-


### PR DESCRIPTION
Also, the CLI relies on xenctrl.lwt running Activations code automatically
more like the version in Mirage-xen does. It also relies on the Xs module
provided (now) by ocaml-xenstore-clients (xenstore_transport opam package)

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
