### PR TITLE
Fix a segfault that happened when a client read from the vchan

### DIFF
--- a/lib/vchan.ml
+++ b/lib/vchan.ml
@@ -72,8 +72,8 @@ let get_rp v = get_ring_shared_prod (get_vchan_interface_right v)
 let set_rp v = set_ring_shared_prod (get_vchan_interface_right v)
 let get_lc v = get_ring_shared_cons (get_vchan_interface_left v)
 let set_lc v = set_ring_shared_cons (get_vchan_interface_left v)
-let get_rc v = get_ring_shared_cons (get_vchan_interface_left v)
-let set_rc v = set_ring_shared_cons (get_vchan_interface_left v)
+let get_rc v = get_ring_shared_cons (get_vchan_interface_right v)
+let set_rc v = set_ring_shared_cons (get_vchan_interface_right v)
 
 type ('a, 'b) result =
   | Ok of 'a


### PR DESCRIPTION
This patch was constructed more by appeal to symmetry than by understanding
the exact nature of the indices. It does stop my client from segfaulting and 
actually causes it to accurately read from the vchan now though, so I have 
confidence that it is correct.

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
