### PR TITLE
When the server closes, clean up its xenstore entries

### DIFF
--- a/lib/vchan.mli
+++ b/lib/vchan.mli
@@ -89,7 +89,7 @@ module type S = sig
   (** [client ~evtchn_h ~domid ~port] connects to a vchan server running
       on [~domid] with [~port]. *)
 
-  val close : t -> unit
+  val close : t -> unit Lwt.t
   (** Close a vchan. This deallocates the vchan and attempts to free
       its resources. The other side is notified of the close, but can
       still read any data pending prior to the close. *)


### PR DESCRIPTION
Further connections to this client will use fresh memory, grants and event
channel ports and will manifest as a fresh FLOW.

Related to #24

Signed-off-by: David Scott dave.scott@citrix.com
