### PR TITLE
xencat: use larger buffers at the high level

### DIFF
--- a/cli/xencat.ml
+++ b/cli/xencat.ml
@@ -24,10 +24,12 @@ let proxy buffer_size (ic, oc) (stdin, stdout) =
   let b_buffer = String.create buffer_size in
   let rec proxy buffer a b =
     Lwt_io.read_into a buffer 0 buffer_size
-    >>= fun n ->
-    Lwt_io.write_from_exactly b buffer 0 n
-    >>= fun () ->
-    proxy buffer a b in
+    >>= function
+    | 0 -> Lwt.fail End_of_file
+    | n ->
+      Lwt_io.write_from_exactly b buffer 0 n
+      >>= fun () ->
+      proxy buffer a b in
   let (a: unit Lwt.t) = proxy a_buffer stdin oc in
   let (b: unit Lwt.t) = proxy b_buffer ic stdout in
   Lwt.catch


### PR DESCRIPTION
Unfortunately we have 3 buffers:
- vchan is a shared buffer, this copies into
- Lwt_io input/output channel buffers, these copy into
- string buffers in the xencat proxy function

If benchmark this with stdin from 'dd if=/dev/zero bs=1M' and stdout redirected to '/dev/null' then it goes at about 90MiB/sec. Not too shabby, but not exactly awesome either. With this performance it makes vchan a decent private copy some files / control some services / log some data channel.

At least a Mirage application can use the FLOW signature and be more efficient (probably).
