### PR TITLE
xen: unmask event channels on listen and connect

### DIFF
--- a/xen/events_xen.ml
+++ b/xen/events_xen.ml
@@ -42,11 +42,14 @@ let send channel =
 let listen domid =
   let h = Eventchn.init () in
   let port = Eventchn.bind_unbound_port h domid in
+  Eventchn.unmask h port;
   Eventchn.to_int port, port
 
 let connect domid port =
   let h = Eventchn.init () in
-  Eventchn.bind_interdomain h domid port
+  let port' = Eventchn.bind_interdomain h domid port in
+  Eventchn.unmask h port';
+  port'
 
 let close channel =
   let h = Eventchn.init () in


### PR DESCRIPTION
The new mini-os is careful to create the channels masked.
We must therefore unmask them before we can use them.

Signed-off-by: David Scott dave.scott@citrix.com

Related to [mirage/mirage#296]
