### PR TITLE
don't build the doc when pinning

### DIFF
--- a/opam
+++ b/opam
@@ -8,7 +8,7 @@ homepage: "http://github.com/mirage/ocaml-vchan"
 license: "ISC"
 build: [
   ["./configure"]
-  [make]
+  [make "build"]
   [make "install"]
 ]
 remove: [["ocamlfind" "remove" "vchan"]]


### PR DESCRIPTION
Avoids lpw25/doc-ock-lib#20 and unnecessary doc rebuilds. If copacetic, will update opam-repository.
