### PR TITLE
adapt to new FLOW result error paradigm

### DIFF
--- a/lib/s.mli
+++ b/lib/s.mli
@@ -117,7 +117,7 @@ module type ENDPOINT = sig
   (** Type of a vchan port name. *)
 
   type error = [
-    `Unknown of string
+    `Msg of string
   ]
 
   val server :
@@ -134,7 +134,6 @@ module type ENDPOINT = sig
 
   include V1_LWT.FLOW
     with type flow = t
-    and  type error := error
     and  type 'a io = 'a Lwt.t
     and  type buffer = Cstruct.t
 end


### PR DESCRIPTION
This PR causes `vchan` to build against a proposed Mirage 3 API, but will break backward compatibility with the current released mirage package set. See mirage/mirage#690 for details on the pull request there.