### PR TITLE
Restore compatibility with cstruct.2.4.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 3.0.1 (2017-06-09)
+* Use the compatibility package cstruct.ppx rather than ppx_cstruct
+  to be compatible with cstruct.2.4.1 and cstruct.3.0.0
+
 ## 3.0.0 (2017-06-08)
 * Split into 3 opam packages:
   * vchan: the platform-independent protocol code

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -3,5 +3,5 @@
   (public_name vchan)
   (libraries (lwt cstruct io-page mirage-flow-lwt result xenstore.client sexplib))
   (c_names (vchan_stubs))
-  (preprocess (pps (ppx_sexp_conv ppx_cstruct -no-check)))
+  (preprocess (pps (ppx_sexp_conv cstruct.ppx -no-check)))
 ))

--- a/vchan-unix.opam
+++ b/vchan-unix.opam
@@ -21,7 +21,7 @@ depends: [
   "jbuilder"  {build & >="1.0+beta9"}
   "vchan"
   "lwt" {>= "2.5.0"}
-  "cstruct" {>= "1.9.0"}
+  "cstruct" {>= "2.4.1"}
   "ppx_tools" {build}
   "ppx_sexp_conv" {build}
   "ppx_cstruct" {build}

--- a/vchan-xen.opam
+++ b/vchan-xen.opam
@@ -21,7 +21,7 @@ depends: [
   "jbuilder"  {build & >="1.0+beta9"}
   "vchan"
   "lwt" {>= "2.5.0"}
-  "cstruct" {>= "1.9.0"}
+  "cstruct" {>= "2.4.1"}
   "ppx_tools" {build}
   "ppx_sexp_conv" {build}
   "ppx_cstruct" {build}

--- a/vchan.opam
+++ b/vchan.opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlfind" {build}
   "jbuilder"  {build & >="1.0+beta9"}
   "lwt" {>= "2.5.0"}
-  "cstruct" {>= "1.9.0"}
+  "cstruct" {>= "2.4.1"}
   "ppx_tools" {build}
   "ppx_sexp_conv" {build}
   "ppx_cstruct" {build}


### PR DESCRIPTION
The findlib package `cstruct.ppx` is preferred to `ppx_cstruct` since it should work with both `cstruct.2.4.1` and `cstruct.3.0.0`

Related to https://github.com/ocaml/opam-repository/pull/9455