### PR TITLE
Fix build

### DIFF
--- a/lib/in_memory.ml
+++ b/lib/in_memory.ml
@@ -28,11 +28,11 @@ module Config = struct
 
   let c = Lwt_condition.create ()
 
-  let write ~client_domid ~port t =
+  let write ~client_domid:_ ~port t =
     Hashtbl.replace tbl port t;
     return ()
 
-  let read ~server_domid ~port =
+  let read ~server_domid:_ ~port =
     let rec loop () =
       if Hashtbl.mem tbl port
       then return (Hashtbl.find tbl port)
@@ -41,7 +41,7 @@ module Config = struct
         loop () in
     loop ()
 
-  let delete ~client_domid ~port =
+  let delete ~client_domid:_ ~port =
     Hashtbl.remove tbl port;
     return ()
 
@@ -81,7 +81,7 @@ module Memory = struct
   let individual_pages = Hashtbl.create 16
   let big_mapping = Hashtbl.create 16
 
-  let share ~domid ~npages ~rw =
+  let share ~domid:_ ~npages ~rw:_ =
     let mapping = Io_page.get npages in
     let grants = get_n npages in
     let share = { grants; mapping } in
@@ -134,7 +134,7 @@ module Memory = struct
     Hashtbl.replace currently_mapped first ();
     { mapping; grants }
 
-  let unmap { mapping; grants } =
+  let unmap { mapping = _; grants } =
     let first = snd (List.hd grants) in
     if Hashtbl.mem currently_mapped first
     then Hashtbl.remove currently_mapped first

--- a/lib/in_memory_events.ml
+++ b/lib/in_memory_events.ml
@@ -20,8 +20,6 @@ open Sexplib.Std
 
 open Lwt
 
-type 'a io = 'a Lwt.t
-
 type port = int [@@deriving sexp_of]
 
 let port_of_string x = `Ok (int_of_string x)

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -149,6 +149,7 @@ let test_write_wraps () = Lwt_main.run (
       for i = 0 to Cstruct.len ring - 1 do Cstruct.set_char ring i 'X' done;
       V.write server ring >>|= fun () ->
       V.read client >>!= fun buf ->
+      assert_equal ~printer:(fun x -> x) (string_of_cstruct ring) (string_of_cstruct buf);
       (* writing and reading 1 byte will ensure we have consumed the previous chunk
          (read doesn't perform a copy, see ack_up_to) *)
       V.write server (cstruct_of_string "!") >>|= fun () ->

--- a/lwt/vchan_lwt_unix.ml
+++ b/lwt/vchan_lwt_unix.ml
@@ -65,8 +65,6 @@ module IO = struct
 
   let write = Lwt_io.write
 
-  let write_line = Lwt_io.write_line
-
   let flush = Lwt_io.flush
 
 end

--- a/vchan-unix.opam
+++ b/vchan-unix.opam
@@ -1,4 +1,5 @@
 opam-version: "1.2"
+synopsis:      "Xen Vchan implementation"
 maintainer:    "jonathan.ludlam@eu.citrix.com"
 authors: [
   "Vincent Bernardoff"

--- a/vchan-xen.opam
+++ b/vchan-xen.opam
@@ -1,4 +1,5 @@
 opam-version: "1.2"
+synopsis:      "Xen Vchan implementation"
 maintainer:    "jonathan.ludlam@eu.citrix.com"
 authors: [
   "Vincent Bernardoff"

--- a/vchan.opam
+++ b/vchan.opam
@@ -1,4 +1,5 @@
 opam-version: "1.2"
+synopsis:      "Xen Vchan implementation"
 maintainer:    "jonathan.ludlam@eu.citrix.com"
 authors: [
   "Vincent Bernardoff"


### PR DESCRIPTION
- Add Synopsis to opam files so opam2 doesn't refuse to build.
- Remove unused values.
- Remove override of |>. We depend on OCaml >= 4.04 anyway.
- Disable errors about unused values generated by cstruct PPX.

With these changes `make` and `make test` now succeed. Hopefully this fixes #107.