### PR TITLE
Export type port = Vchan.Port.t in Unix API

### DIFF
--- a/lwt/vchan_lwt_unix.mli
+++ b/lwt/vchan_lwt_unix.mli
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module M: Vchan.S.ENDPOINT
+module M: Vchan.S.ENDPOINT with type port = Vchan.Port.t
 
 module type Cohttp_IO_S = sig
   type +'a t


### PR DESCRIPTION
Without this, parts of the API are unusable because there is no way to create a port. The equivalent type equality is already exposed in `xen/vchan_xen.mli`.