### PR TITLE
Update to new OS.Xen grant API

### DIFF
--- a/lib/endpoint.ml
+++ b/lib/endpoint.ml
@@ -31,6 +31,7 @@ end
 
 module Opt = struct
   let iter f o = match o with Some e -> f e | None -> ()
+  let iter_lwt f o = match o with Some e -> f e | None -> Lwt.return_unit
 end
 
 (* GCC atomic stuff *)
@@ -519,9 +520,9 @@ let close (vch: t) =
       C.delete ~client_domid:vch.remote_domid ~port:vch.remote_port
       >>= fun () ->
 
-      Opt.iter M.unshare read_shr;
-      Opt.iter M.unshare write_shr;
-      M.unshare shr_shr;
+      Opt.iter_lwt M.unshare read_shr >>= fun () ->
+      Opt.iter_lwt M.unshare write_shr >>= fun () ->
+      M.unshare shr_shr >>= fun () ->
       E.close vch.evtchn;
       return ()
   end

--- a/lib/in_memory.ml
+++ b/lib/in_memory.ml
@@ -100,7 +100,8 @@ module Memory = struct
 
   let unshare share =
     List.iter (fun grant -> remove individual_pages grant) share.grants;
-    remove big_mapping (List.hd share.grants)
+    remove big_mapping (List.hd share.grants);
+    Lwt.return_unit
 
   type mapping = {
     mapping: page;

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -49,7 +49,7 @@ module type MEMORY = sig
 
   val share: domid:int -> npages:int -> rw:bool -> share
 
-  val unshare: share -> unit
+  val unshare: share -> unit Lwt.t
 
   type mapping [@@deriving sexp_of]
 

--- a/lwt/memory_lwt_unix.ml
+++ b/lwt/memory_lwt_unix.ml
@@ -48,7 +48,8 @@ let share ~domid ~npages ~rw =
 let unshare s =
   let i = gntshr_interface_open () in
   let s' = { Gnt.Gntshr.refs = List.map Int32.to_int s.grants; mapping = s.mapping } in
-  Gnt.Gntshr.munmap_exn i s'
+  Gnt.Gntshr.munmap_exn i s';
+  Lwt.return ()
 
 let gnttab_interface_open =
   let cache = ref None in

--- a/vchan-xen.opam
+++ b/vchan-xen.opam
@@ -19,7 +19,7 @@ depends: [
   "io-page"
   "mirage-flow-lwt" {>= "1.0.0"}
   "xenstore" {>= "1.2.2"}
-  "mirage-xen"
+  "mirage-xen" {>= "3.3.0"}
   "xenstore_transport" {>= "1.0.0"}
   "sexplib"
   "cmdliner"


### PR DESCRIPTION
(see https://github.com/mirage/mirage-xen/pull/9)

- `Gntref.t` is now abstract - update sexp converters to use `to_int32`/`from_int32`.
- `gntshr_interface_open` is no longer needed.
- Instead of wrapping the underlying share type with our own (that just converts the grant refs to `int32`), use the underlying object directly. This is needed because `Export.t` is now abstract and we so cannot create them ourselves, but it seems simpler this way too.
- The new `Export.unshare` requires us to say whether to release the grant refs too. It looks like we should have been doing this, so I passed `true` here, although the original code didn't. The old Gnt API was a bit vague about this; it looks like it released the refs on Unix but not on Xen.

Note that no version of mirage-xen with the new API has been released yet, so we might want to wait for that before merging.

/cc @yomimono 