### PR TITLE
remove result dependency (ocaml >= 4.04 is required anyways)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,6 @@
 (library
  (name vchan)
  (public_name vchan)
- (libraries lwt cstruct io-page mirage-flow-lwt result xenstore.client sexplib)
+ (libraries lwt cstruct io-page mirage-flow-lwt xenstore.client sexplib)
  (c_names vchan_stubs)
  (preprocess (pps ppx_sexp_conv ppx_cstruct -no-check)))

--- a/lib/endpoint.ml
+++ b/lib/endpoint.ml
@@ -16,7 +16,6 @@
 open S
 open Sexplib.Std
 open Lwt
-open Result
 
 let ( >>= ) = Lwt.bind
 

--- a/vchan-unix.opam
+++ b/vchan-unix.opam
@@ -25,7 +25,6 @@ depends: [
   "xen-gnt-unix"
   "sexplib"
   "cmdliner"
-  "result"
   "ounit" {with-test}
 ]
 build: [

--- a/vchan-xen.opam
+++ b/vchan-xen.opam
@@ -23,7 +23,6 @@ depends: [
   "xenstore_transport" {>= "1.0.0"}
   "sexplib"
   "cmdliner"
-  "result"
   "ounit" {with-test}
 ]
 build: [

--- a/vchan.opam
+++ b/vchan.opam
@@ -26,7 +26,6 @@ depends: [
   "xenstore_transport" {>= "1.0.0"}
   "sexplib"
   "cmdliner"
-  "result"
   "ounit" {with-test}
 ]
 build: [


### PR DESCRIPTION
now with 4.08 providing a `Result` module, we should get rid of the `result` package dependency (also, vchan*opam already require >= 4.04.0, and `type result` was introduced in Pervasives in 4.03)