### PR TITLE
Use result

### DIFF
--- a/lib/endpoint.ml
+++ b/lib/endpoint.ml
@@ -213,10 +213,10 @@ let sexp_of_t (t: t) =
     with Ok st -> Some st | _ -> None in
   let left_order =
     match Location.of_order (get_vchan_interface_left_order t.shared_page)
-    with `Ok x -> Some x | _ -> None in
+    with Ok x -> Some x | _ -> None in
   let right_order =
     match Location.of_order (get_vchan_interface_right_order t.shared_page)
-    with `Ok x -> Some x | _ -> None in
+    with Ok x -> Some x | _ -> None in
   let read_producer = rd_prod t in
   let read_consumer = rd_cons t in
   let read = Cstruct.to_string t.read in
@@ -434,8 +434,8 @@ let server ~domid ~port ?(read_size=1024) ?(write_size=1024) () =
   return vch
 
 let (>>|=) m f = match m with
-| `Ok x -> f x
-| `Error m -> fail (Failure m)
+| Ok x -> f x
+| Error (`Msg m) -> fail (Failure m)
 
 let client ~domid ~port () =
   C.read ~server_domid:domid ~port

--- a/lib/in_memory_events.ml
+++ b/lib/in_memory_events.ml
@@ -22,7 +22,7 @@ open Lwt
 
 type port = int [@@deriving sexp_of]
 
-let port_of_string x = `Ok (int_of_string x)
+let port_of_string x = Ok (int_of_string x)
 let string_of_port = string_of_int
 
 let next_port = ref 0

--- a/lib/location.ml
+++ b/lib/location.ml
@@ -41,11 +41,11 @@ let to_order = function
   | External n -> n + 12
 
 let of_order = function
-  | 10 -> `Ok (Within_shared_page First)
-  | 11 -> `Ok (Within_shared_page Second)
-  | n when n >= 12 -> `Ok (External (n - 12))
-  | x -> `Error (Printf.sprintf "Invalid ring order: %d" x)
- 
+  | 10 -> Ok (Within_shared_page First)
+  | 11 -> Ok (Within_shared_page Second)
+  | n when n >= 12 -> Ok (External (n - 12))
+  | x -> Error (`Msg (Printf.sprintf "Invalid ring order: %d" x))
+
 (* in increasing order of bytes *)
 let all = [
   Within_shared_page First; Within_shared_page Second;

--- a/lib/location.mli
+++ b/lib/location.mli
@@ -36,7 +36,7 @@ val to_order: t -> int
 (** [to_order t] gives the 'order' which is shared via the metadata
     page and used to uniquely identify the location *)
 
-val of_order: int -> [ `Ok of t | `Error of string ]
+val of_order: int -> (t, [> `Msg of string ]) result
 (** [of_order x] parses the order *)
 
 val of_lengths: int -> int -> t * t

--- a/lib/port.ml
+++ b/lib/port.ml
@@ -28,7 +28,11 @@ let of_string x =
     (n = String.length x)
     || (valid_char x.[n] && loop (n + 1)) in
   if loop 0 && (String.length x > 0)
-  then `Ok x
-  else `Error (Printf.sprintf "A Vchan port must match [a-zA-Z0-9_-]+; therefore '%s' is invalid." (String.escaped x))
+  then Ok x
+  else
+    let msg = Printf.sprintf "A Vchan port must match [a-zA-Z0-9_-]+; \
+                              therefore %S is invalid." x
+    in
+    Error (`Msg msg)
 
 let to_string t = t

--- a/lib/port.mli
+++ b/lib/port.mli
@@ -16,6 +16,6 @@
 
 type t [@@deriving sexp]
 
-val of_string: string -> [ `Ok of t | `Error of string ]
+val of_string: string -> (t, [> `Msg of string ]) result
 
 val to_string: t -> string

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -71,7 +71,7 @@ module type EVENTS = sig
       finally calls to [connect] creates a channel between the two domains.
       Events are send and received over these channels. *)
 
-  val port_of_string: string -> [ `Ok of port | `Error of string ]
+  val port_of_string: string -> (port, [> `Msg of string ]) result
   val string_of_port: port -> string
 
   type channel [@@deriving sexp_of]

--- a/lib_test/mirage/unikernel.ml
+++ b/lib_test/mirage/unikernel.ml
@@ -54,10 +54,10 @@ module Server (C: Mirage_console_lwt.S) = struct
          C.log c (sprintf "remote domid is %d and port is %s" remote_domid port) >>= fun () ->
          Vchan.Port.of_string port
          |> function
-         |`Error e ->
+         | Error (`Msg e) ->
            C.log c e >>= fun () ->
            fail (Failure "error making port")
-         |`Ok port ->
+         | Ok port ->
            C.log c "creating server" >>= fun () ->
            VX.server ~domid:remote_domid ~port ~read_size:4096 ~write_size:4096 ()
            >>= read_all c
@@ -80,8 +80,8 @@ module Client (C: Mirage_console_lwt.S) = struct
     >>= fun () ->
     Vchan.Port.of_string port
     |> function
-    |`Error _ -> fail (Failure "error making port")
-    |`Ok port ->
+    | Error _ -> fail (Failure "error making port")
+    | Ok port ->
       OS.Time.sleep_ns (Duration.of_sec 2) >>= fun () ->
       VX.client ~domid:remote_domid ~port ()
       >>= fun t ->

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -23,8 +23,8 @@ let () =
   ()
 
 let port = match Vchan.Port.of_string "test" with
-| `Error _ -> failwith "Failed to parse test port"
-| `Ok x -> x
+| Error _ -> failwith "Failed to parse test port"
+| Ok x -> x
 
 open Lwt
 

--- a/lwt/events_lwt_unix.ml
+++ b/lwt/events_lwt_unix.ml
@@ -19,9 +19,10 @@ type port = int [@@deriving sexp_of]
 
 let port_of_string x =
   try
-    `Ok (int_of_string x)
+    Ok (int_of_string x)
   with _ ->
-    `Error (Printf.sprintf "Valid ports must be integers; got '%s'" (String.escaped x))
+    let msg = Printf.sprintf "Valid ports must be integers; got %S" x in
+    Error (`Msg msg)
 
 let string_of_port = string_of_int
 

--- a/xen/events_xen.ml
+++ b/xen/events_xen.ml
@@ -21,9 +21,10 @@ type port = int [@@deriving sexp_of]
 
 let port_of_string x =
   try
-    `Ok (int_of_string x)
+    Ok (int_of_string x)
   with _ ->
-    `Error (Printf.sprintf "Valid ports must be integers; got '%s'" (String.escaped x))
+    let msg = Printf.sprintf "Valid ports must be integers; got %S" x in
+    Error (`Msg msg)
 
 let string_of_port = string_of_int
 


### PR DESCRIPTION
this fixes #113 (and is on top of #129) -- though it changes the API (Location.of_order and Port.of_string now use result, thus reverse dependencies will have to be adapted).