### PR TITLE
Don't ignore 'junk'

### DIFF
--- a/lib/endpoint.ml
+++ b/lib/endpoint.ml
@@ -454,9 +454,6 @@ let client ~domid ~port () =
   let nb_left_pages = Location.to_length lo / 4096 in
   let nb_right_pages = Location.to_length ro / 4096 in
 
-  (* Ignore trailing junk in v *)
-  let v = Cstruct.sub v 0 (sizeof_vchan_interface+4*(nb_left_pages+nb_right_pages)) in
-
   (* Bind the event channel *)
   let evtchn = E.connect domid unbound_port in
 


### PR DESCRIPTION
It's not always junk! If sufficiently small buffers are needed they can fit in the ring page (`Within_shared_page`). The Linux implementation doesn't seem to take advantage of this in practice, but we do in MirageOS(!) https://github.com/mirage/ocaml-vchan/blob/master/lib/endpoint.ml#L356

I stumbled on this while trying to make qrexec calls between MirageOS unikernels in QubesOS.