### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/vchan-unix.opam
+++ b/vchan-unix.opam
@@ -9,7 +9,7 @@ doc: "https://mirage.github.io/ocaml-vchan"
 bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune" {build}
+  "dune"
   "vchan" {= version}
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "1.9.0"}

--- a/vchan-xen.opam
+++ b/vchan-xen.opam
@@ -9,7 +9,7 @@ doc: "https://mirage.github.io/ocaml-vchan"
 bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune" {build}
+  "dune"
   "vchan" {=version}
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "1.9.0"}

--- a/vchan.opam
+++ b/vchan.opam
@@ -14,7 +14,7 @@ doc: "https://mirage.github.io/ocaml-vchan"
 bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune" {build}
+  "dune"
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "1.9.0"}
   "ppx_tools"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.