### PR TITLE
Update to new Xen core platform stack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   global:
   - PINS="vchan:. vchan-unix:. vchan-xen:."
   matrix:
-  - PACKAGE="vchan-xen" DISTRO="debian-stable" OCAML_VERSION="4.06"
-  - PACKAGE="vchan-unix" DISTRO="debian-testing" OCAML_VERSION="4.07"
-  - PACKAGE="vchan-xen" DISTRO="debian-stable" OCAML_VERSION="4.08"
-  - PACKAGE="vchan" DISTRO="debian-stable" OCAML_VERSION="4.09"
+  - PACKAGE="vchan-xen" DISTRO="debian-stable" OCAML_VERSION="4.10"
+  - PACKAGE="vchan-unix" DISTRO="debian-testing" OCAML_VERSION="4.09"
+  - PACKAGE="vchan-xen" DISTRO="debian-stable" OCAML_VERSION="4.09"
+  - PACKAGE="vchan" DISTRO="debian-stable" OCAML_VERSION="4.08"

--- a/vchan-unix.opam
+++ b/vchan-unix.opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/mirage/ocaml-vchan"
 doc: "https://mirage.github.io/ocaml-vchan"
 bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.08.0"}
   "dune"
   "vchan" {= version}
   "lwt" {>= "2.5.0"}

--- a/vchan-xen.opam
+++ b/vchan-xen.opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/mirage/ocaml-vchan"
 doc: "https://mirage.github.io/ocaml-vchan"
 bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.08.0"}
   "dune"
   "vchan" {=version}
   "lwt" {>= "2.5.0"}

--- a/vchan-xen.opam
+++ b/vchan-xen.opam
@@ -18,7 +18,7 @@ depends: [
   "io-page"
   "mirage-flow" {>= "2.0.0"}
   "xenstore" {>= "1.2.2"}
-  "mirage-xen" {>= "5.0.0"}
+  "mirage-xen" {>= "6.0.0"}
   "xenstore_transport" {>= "1.0.0"}
   "sexplib"
   "cmdliner"

--- a/vchan.opam
+++ b/vchan.opam
@@ -13,7 +13,7 @@ homepage: "https://github.com/mirage/ocaml-vchan"
 doc: "https://mirage.github.io/ocaml-vchan"
 bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.08.0"}
   "dune"
   "lwt" {>= "2.5.0"}
   "cstruct" {>= "1.9.0"}

--- a/xen/dune
+++ b/xen/dune
@@ -1,6 +1,6 @@
 (library
  (name vchan_xen)
  (public_name vchan-xen)
- (libraries lwt xen-evtchn xenstore xenstore.client mirage-xen mirage-flow vchan)
+ (libraries lwt xenstore xenstore.client mirage-xen mirage-flow vchan)
  (wrapped false)
  (preprocess (pps ppx_sexp_conv)))

--- a/xen/events_xen.ml
+++ b/xen/events_xen.ml
@@ -26,8 +26,8 @@ let port_of_string x =
 
 let string_of_port = string_of_int
 
-type channel = Eventchn.t
-let sexp_of_channel x = Sexplib.Sexp.Atom (string_of_int (Eventchn.to_int x))
+type channel = OS.Eventchn.t
+let sexp_of_channel x = Sexplib.Sexp.Atom (string_of_int (OS.Eventchn.to_int x))
 
 type event = OS.Activations.event
 let sexp_of_event _ = Sexplib.Sexp.Atom "<event>"
@@ -37,21 +37,21 @@ let initial = OS.Activations.program_start
 let recv = OS.Activations.after
 
 let send channel =
-  let h = Eventchn.init () in
-  Eventchn.notify h channel
+  let h = OS.Eventchn.init () in
+  OS.Eventchn.notify h channel
 
 let listen domid =
-  let h = Eventchn.init () in
-  let port = Eventchn.bind_unbound_port h domid in
-  Eventchn.unmask h port;
-  Eventchn.to_int port, port
+  let h = OS.Eventchn.init () in
+  let port = OS.Eventchn.bind_unbound_port h domid in
+  OS.Eventchn.unmask h port;
+  OS.Eventchn.to_int port, port
 
 let connect domid port =
-  let h = Eventchn.init () in
-  let port' = Eventchn.bind_interdomain h domid port in
-  Eventchn.unmask h port';
+  let h = OS.Eventchn.init () in
+  let port' = OS.Eventchn.bind_interdomain h domid port in
+  OS.Eventchn.unmask h port';
   port'
 
 let close channel =
-  let h = Eventchn.init () in
-  Eventchn.unbind h channel
+  let h = OS.Eventchn.init () in
+  OS.Eventchn.unbind h channel


### PR DESCRIPTION
Update vchan-xen to the interface changes in the new Xen core
platform stack.

Part of mirage/mirage#1159, depends on mirage/mirage-xen#23.